### PR TITLE
Fixed an issue where IPv4 & IPv6 test were being compared together

### DIFF
--- a/perfsonar_traceroute_analysis.py
+++ b/perfsonar_traceroute_analysis.py
@@ -148,7 +148,7 @@ def main(perfsonar_ma_url, time_period):
         # Creates force nodes between previous and current hop
         force_graph.create_force_nodes(route_stats, route_from_source, destination)
         # Compares current route with previous and stores current route in PREVIOUS_ROUTE_FP
-        route_compare(source_domain, destination_domain, route_stats)
+        route_compare(src_ip=source, dest_ip=destination, route_stats=route_stats)
 
     if ENABLE_EMAIL_ALERTS and route_comparison.email_contents:
         route_comparison.send_email_alert()


### PR DESCRIPTION
Issue: If a traceroute test was conducted from a source to destination
       endpoint, using both IPv4 and IPv6 and with exactly the same
       domain names for v4 and v6, RouteComparison would mistakenly
       compare the IPv4 test with its IPv6 counterpart. Therefore
       the network admin would be notified of incorrect changes
       to the network path.

Solution: Changed route_compare arguments within
          perfsonar_traceroute_analysis.py to receive the source and
          destination IP instead of their respective domain names. Thus
          this will modify the source and destination keys
          of the previous_routes.json file.