### PR TITLE
Presenting unknown hops as asterisks instead of using 'null tag:'

### DIFF
--- a/classes/matrix.py
+++ b/classes/matrix.py
@@ -207,7 +207,7 @@ class ForceGraph(DataStore):
         """
         raise AttributeError("'ForceGraph' object has no attribute 'update_from_json_file'")
 
-    def create_force_nodes(self, hop_details, previous_hop, destination_ip):
+    def create_force_nodes(self, hop_details, previous_hop, source_ip, destination_ip):
         """
         Creates a force node dictionary entry which will be appended to the force graph list.
         Example dictionary:
@@ -227,15 +227,11 @@ class ForceGraph(DataStore):
         :type destination_ip: str
         :return: None
         """
-        if not isinstance(hop_details, list):
-            hop_details = [hop_details]
-        if not isinstance(previous_hop, list):
-            previous_hop = [previous_hop]
-
         if len(hop_details) != len(previous_hop):
             print("Error: Hop information and previous hop list are of different length!")
             return
 
+        unique_tag = 'null tag:{index}_%s_%s' %(source_ip, destination_ip)
         for index, hop in enumerate(hop_details):
             node_point = ""
             if hop["ip"] == destination_ip:
@@ -243,7 +239,9 @@ class ForceGraph(DataStore):
             elif index == 0:
                 node_point = "source"
 
-            self.data_store.append({"source": previous_hop[index],
-                                    "target": hop["domain"],
+            source = unique_tag.format(index=index) if '*' in previous_hop[index] else previous_hop[index]
+            target = unique_tag.format(index=index+1) if '*' in hop["domain"] else hop["domain"]
+            self.data_store.append({"source": source,
+                                    "target": target,
                                     "type": hop["status"],
                                     "node_point": node_point})

--- a/classes/pstrace.py
+++ b/classes/pstrace.py
@@ -62,10 +62,11 @@ class PsTrace:
 
             # Creates the hop list from the route_stats return
             route_from_source = [traceroute.information['source_domain']] + [hop["domain"] for hop in
-                                                                       traceroute.information['route_stats']][:-1]
+                                                                             traceroute.information['route_stats']][:-1]
             # Creates force nodes between previous and current hop
             self.force_graph.create_force_nodes(traceroute.information['route_stats'],
                                                 route_from_source,
+                                                traceroute.information['source_ip'],
                                                 traceroute.information['destination_ip'])
             # Compares current route with previous and stores current route in PREVIOUS_ROUTE_FP
             self.route_comparison.check_changes(traceroute.information)

--- a/html_templates/matrix.html.j2
+++ b/html_templates/matrix.html.j2
@@ -206,12 +206,21 @@
                 })
                 .call(force.drag);
 
+            <!-- TODO: Determine a better solution instead of processing against node names twice -->
             var text = svg.append('g').selectAll('text')
                 .data(force.nodes())
                 .enter().append('text')
-                .attr('x', -40)
                 .attr('y', '.31em')
+                .attr('x', function(d) {
+                    if (d.name.includes('null tag')) {
+                        return 0
+                    }
+                    return -40
+                 })
                 .text(function(d) {
+                    if (d.name.includes('null tag')) {
+                        return '*';
+                    }
                     return d.name;
                 });
             // Use elliptical arc path segments to doubly-encode directionality.


### PR DESCRIPTION
Issue: Previously used a unique tag to differentiate the number of
       unknown hops that occurred during a traceroute test. Received
       feedback that the unique tags aka 'null tag:index_destination'
       looked messy. The reason for using unique tags was for the
       D3.js force graph which needed a unique tag to separate
       traceroutes test from each other if an asterisk was used instead.

Resolution: Changed main script to use asterisks instead of 'null tags'
            and created a specific 'null tag' only for the force graph.
            The matrix.html.j2 template checks if the 'null tag' exists
            and presents it as an asterisks without causing unrelated
            traceroute tests interacting with one another inside the
            force graph.