### PR TITLE
Made _tidy_route_slice cut rtt hops instead of all keys in route

### DIFF
--- a/classes/traceroute/analysis.py
+++ b/classes/traceroute/analysis.py
@@ -47,7 +47,8 @@ class TracerouteAnalysis(Jinja2Template):
         :param route: traceroute route
         :return: None or slice to be performed on route
         """
-        if '*' not in route[-1].values():
+
+        if '*' not in str(route[-1]['rtt']):
             return
         route_reversed = reversed(route)
         count = -1


### PR DESCRIPTION
Issue: _tidy_route_slice was checking for unknown `*` entries in the
       route dictionary. When there were unknown entries for all ASN
       hops, it would cut down the traceroutes to the first hop even
       though IP/domains + RTT were found in subsequent hops.

Solution: Only checking for trailing RTT unknowns within the traceroute